### PR TITLE
Fix broken loops for multiplayer

### DIFF
--- a/src/main/java/me/pikamug/MobArenaQuests/MobArenaCompleteObjective.java
+++ b/src/main/java/me/pikamug/MobArenaQuests/MobArenaCompleteObjective.java
@@ -44,7 +44,7 @@ public class MobArenaCompleteObjective extends CustomObjective implements Listen
 		for (Player survivor : survivors) {
 			Quester quester = quests.getQuester(survivor.getUniqueId());
 			if (quester == null) {
-				return;
+				continue;
 			}
 			String arenaName = event.getArena().arenaName();
 			for (Quest q : quester.getCurrentQuests().keySet()) {
@@ -58,10 +58,9 @@ public class MobArenaCompleteObjective extends CustomObjective implements Listen
 					for (String str : spl) {
 						if (str.equals("ANY") || arenaName.equalsIgnoreCase(str)) {
 							incrementObjective(survivor, this, 1, q);
-							return;
+							break;
 						}
 					}
-					return;
 				}
 			}
 		}

--- a/src/main/java/me/pikamug/MobArenaQuests/MobArenaKillObjective.java
+++ b/src/main/java/me/pikamug/MobArenaQuests/MobArenaKillObjective.java
@@ -53,13 +53,13 @@ public class MobArenaKillObjective extends CustomObjective implements Listener {
 			if (datamap != null) {
 				String mobNames = (String)datamap.getOrDefault("MA Kill Names", "ANY");
 				if (mobNames == null) {
-					return;
+					continue;
 				}
 				String[] spl = mobNames.split(",");
 				for (String str : spl) {
 					if (str.equals("ANY") || mobName.equalsIgnoreCase(str)) {
 						incrementObjective(killer, this, 1, q);
-						return;
+						break;
 					}
 				}
 			}

--- a/src/main/java/me/pikamug/MobArenaQuests/MobArenaWaveObjective.java
+++ b/src/main/java/me/pikamug/MobArenaQuests/MobArenaWaveObjective.java
@@ -44,7 +44,7 @@ public class MobArenaWaveObjective extends CustomObjective implements Listener {
 		for (Player player : players) {
 			Quester quester = quests.getQuester(player.getUniqueId());
 			if (quester == null) {
-				return;
+				continue;
 			}
 			String arenaName = event.getArena().arenaName();
 			for (Quest q : quester.getCurrentQuests().keySet()) {
@@ -58,10 +58,9 @@ public class MobArenaWaveObjective extends CustomObjective implements Listener {
 					for (String str : spl) {
 						if (str.equals("ANY") || arenaName.equalsIgnoreCase(str)) {
 							incrementObjective(player, this, 1, q);
-							return;
+							break;
 						}
 					}
-					return;
 				}
 			}
 		}


### PR DESCRIPTION
Every quest objective uses `return` after assessing only the first player and the first matching quest objective.

This means in multiplayer, only one random player who survived the MobArena gets quest credit for it, for only one matching quest. And if that player happens to not have an active matching quest, no one does.

Bad. Me fix.